### PR TITLE
✨ feat: Add Terraform S3 backend for state management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Compiled files
+*.tfstate
+*.tfstate.backup
+
+# Module directory
+.terraform/
+
+# vim
+tags
+*~
+
+# Jetbrains
+.idea
+*.iml

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,32 @@
+###########################################
+# <emoji> <type>: <subject>
+
+# [optional body]
+
+# [optional footer]
+###########################################
+
+# 위와 같은 구조로 커밋을 작성해 주세요.
+# subject에는 마침표를 생략합니다.
+
+################ emoji & type list ################
+# 🏗 build    : build system과 관련된 코드 수정 (gulp, Jenkinsfile, Dockerfile 등)
+# 👷 ci       : ci 설정 파일 혹은 스크립트 수정 (Jenkinsfile, Circle, Travis 등)
+# 📝 docs     : 문서 수정 (markdown, txt 파일 등)
+# ✨ feat     : 새로운 기능 개발
+# 🐛 fix      : 버그 픽스
+# 🚑 hotfix   : Hot 픽스
+# ⚡️ perf     : 퍼포먼스 향상을 위한 코드 수정
+# ♻️ refactor  : 버그 픽스 혹은 새로운 기능 개발이 아닌 코드 수정
+# 💄 style    : 코드가 가진 의미에 영향을 주지 않는 코드 수정 (공백, 포매팅, 세미콜론 등)
+# ✅ test     : 이전에 추가하지 못한 테스트 코드 추가 혹은 존재하던 테스트 코드 올바르게 수정
+# 🍰 sample   : sample 코드 수정
+# 🙈 chore    : 그 외의 단순한 수정 (.gitignore 수정 등)
+
+################# example #################
+# ✨ feat: graphql-api-template base foundation & architecture
+#
+# writing the base foundation and architecture for a graphql-api-template, 
+# intended for the independent construction of repositories for each service under the same format, 
+# in the context of microservice architecture.
+###########################################

--- a/global/s3/.terraform.lock.hcl
+++ b/global/s3/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.5.0"
+  hashes = [
+    "h1:RW3BccpFsLA0PrYWrQb/UG0TQHe2c0c5ZXYXJeVm4LU=",
+    "zh:10fe0ef4191323c920c1844f27dbc88114547d5f78fad915c1769c908f40d916",
+    "zh:565fc7c3a1f42474fa75f143cb8115e11b894ed7fd9973569b00bd429fb92b4e",
+    "zh:5ba6132b1d442ed679ad8ea89fb5602aa0893e8dcd002a52ab3d76591aa18c8b",
+    "zh:5c2580630cd5034bae800445074c17950aea17f089bcdae7af637173122f8b03",
+    "zh:656d77220c6053fd5adb86d3bfb57dd42f98220d81590ffd643156ffeca36608",
+    "zh:65c7b3e333b734ce641735a23539d4fb392a675a5a9b892e8369781b1f3386a2",
+    "zh:682d55b2e6e9c40e20d679aa53d561797b1f3450e5187c9f4e8c359b69f06df3",
+    "zh:79ebc0993d6128819d70dd896cd743e3bab3e3cdc4c02f2a2dbd138471c23179",
+    "zh:8d44214c738f0410f829e1c761b021c92b3364daf9fcd08097216cc84eaff997",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a0b1bc008e95c5a7285f5e7dd116ce60ba7a6c1c3bd8ac3e3b63d4e1438d8e49",
+    "zh:cf40fb60efc5df42fc5716c7e458868251c82fc78b623f12d1bc994b6fcc7ef2",
+    "zh:cfd8f3f391cddecfc5e44fe57f0633067470e9038517115ba69d8ee533d5d74e",
+    "zh:d6552490599e02a756e72b7091b591493cee25548ce7120ad05210b4ff2492bd",
+    "zh:f77dfe665fd4b3d9e36fdc989d7feff4cf6bf17161c0b1a0f25a0fcf402c779d",
+  ]
+}

--- a/global/s3/backend.tf
+++ b/global/s3/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "bellti9er-tf-state-prod"
+    key     = "global/s3/terraform.state"
+    region  = "ap-northeast-2"
+    profile = "bellti9er"
+  }
+}

--- a/global/s3/main.tf
+++ b/global/s3/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "ap-northeast-2"
+
+  # Terraform by default looks at the ~/.aws/credentials file 
+  # for the aws access key and secret.
+  # The profile config tells which profile credential
+  # to look at in the aws credential file.
+  profile = "bellti9er"
+}
+
+resource "aws_s3_bucket" "terraform_state_prod" {
+  bucket = "bellti9er-tf-state-prod"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state_prod_versioning" {
+  bucket = aws_s3_bucket.terraform_state_prod.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
## 작업 배경

- Terraform 상태를 저장하고 관리하기 위해 AWS S3 버킷을 활용합니다.
- 이는 Terraform이 관리하는 인프라의 상태를 안전하게 유지하고, 여러명의 개발자가 Terraform을 통해 인프라를 관리할 때의 문제를 방지하는데 도움이 됩니다. 

</br>

## 작업 내용 

- `aws_s3_bucket`, `aws_s3_bucket_versioning` 과 같은 두가지 리소스를 활용하여 s3 버킷을 생성하고 이에 대한 버전을 관리할 수 있도록 합니다.
- 해당 버킷이 Terraform에 의해 실수로 destory 되는 것을 방지하기 위한 설정을 추가합니다.

</br>