### PR TITLE
✨ feat: Implement management and staging VPCs with peering

### DIFF
--- a/management/vpc/.terraform.lock.hcl
+++ b/management/vpc/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.5.0"
+  hashes = [
+    "h1:RW3BccpFsLA0PrYWrQb/UG0TQHe2c0c5ZXYXJeVm4LU=",
+    "zh:10fe0ef4191323c920c1844f27dbc88114547d5f78fad915c1769c908f40d916",
+    "zh:565fc7c3a1f42474fa75f143cb8115e11b894ed7fd9973569b00bd429fb92b4e",
+    "zh:5ba6132b1d442ed679ad8ea89fb5602aa0893e8dcd002a52ab3d76591aa18c8b",
+    "zh:5c2580630cd5034bae800445074c17950aea17f089bcdae7af637173122f8b03",
+    "zh:656d77220c6053fd5adb86d3bfb57dd42f98220d81590ffd643156ffeca36608",
+    "zh:65c7b3e333b734ce641735a23539d4fb392a675a5a9b892e8369781b1f3386a2",
+    "zh:682d55b2e6e9c40e20d679aa53d561797b1f3450e5187c9f4e8c359b69f06df3",
+    "zh:79ebc0993d6128819d70dd896cd743e3bab3e3cdc4c02f2a2dbd138471c23179",
+    "zh:8d44214c738f0410f829e1c761b021c92b3364daf9fcd08097216cc84eaff997",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a0b1bc008e95c5a7285f5e7dd116ce60ba7a6c1c3bd8ac3e3b63d4e1438d8e49",
+    "zh:cf40fb60efc5df42fc5716c7e458868251c82fc78b623f12d1bc994b6fcc7ef2",
+    "zh:cfd8f3f391cddecfc5e44fe57f0633067470e9038517115ba69d8ee533d5d74e",
+    "zh:d6552490599e02a756e72b7091b591493cee25548ce7120ad05210b4ff2492bd",
+    "zh:f77dfe665fd4b3d9e36fdc989d7feff4cf6bf17161c0b1a0f25a0fcf402c779d",
+  ]
+}

--- a/management/vpc/backend.tf
+++ b/management/vpc/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "bellti9er-tf-state-prod"
+    key     = "management/vpc.state"
+    region  = "ap-northeast-2"
+    profile = "bellti9er"
+  }
+}

--- a/management/vpc/main.tf
+++ b/management/vpc/main.tf
@@ -1,0 +1,142 @@
+provider "aws" {
+  region = "ap-northeast-2"
+  
+  # Terraform by default looks at the ~/.aws/credentials file 
+  # for the aws access key and secret.
+  # The profile config tells which profile credential
+  # to look at in the aws credential file.
+  profile = "bellti9er"
+}
+
+############################################################
+# Management
+############################################################
+resource "aws_vpc" "management" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "Management"
+  }
+}
+
+############################################################
+# Public Subnets
+############################################################
+resource "aws_subnet" "management_public_subnet_1" {
+  vpc_id            = aws_vpc.management.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "Management Public Subnet 1"
+  }
+}
+
+resource "aws_subnet" "management_public_subnet_2" {
+  vpc_id            = aws_vpc.management.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "ap-northeast-2b"
+
+  tags = {
+    Name = "Management Public Subnet 2"
+  }
+}
+
+############################################################
+# Private Subnets
+############################################################
+resource "aws_subnet" "management_private_subnet_1" {
+  vpc_id            = aws_vpc.management.id
+  cidr_block        = "10.0.4.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "Management Private Subnet 1"
+  }
+}
+
+resource "aws_subnet" "management_private_subnet_2" {
+  vpc_id            = aws_vpc.management.id
+  cidr_block        = "10.0.6.0/24"
+  availability_zone = "ap-northeast-2b"
+
+  tags = {
+    Name = "Management Private Subnet 2"
+  }
+}
+
+############################################################
+# EIP
+############################################################
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+############################################################
+# Routing table for public subnets
+############################################################
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.management.id
+
+  tags = {
+    Name = "Management Internet Gateway"
+  }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.management.default_route_table_id
+
+  tags = {
+    Name = "Management Public Default Route Table"
+  }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_vpc.management.default_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.ig.id
+}
+
+resource "aws_route_table_association" "public_1" {
+  subnet_id      = aws_subnet.management_public_subnet_1.id
+  route_table_id = aws_vpc.management.default_route_table_id
+}
+
+resource "aws_route_table_association" "public_2" {
+  subnet_id      = aws_subnet.management_public_subnet_2.id
+  route_table_id = aws_vpc.management.default_route_table_id
+}
+
+############################################################
+# Routing table for private subnets
+############################################################
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.management_public_subnet_1.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.management.id
+
+  tags = {
+    Name = "Management Private Route Table"
+  }
+}
+
+resource "aws_route" "private" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat.id
+}
+
+resource "aws_route_table_association" "private_1" {
+  subnet_id      = aws_subnet.management_private_subnet_1.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_2" {
+  subnet_id      = aws_subnet.management_private_subnet_2.id
+  route_table_id = aws_route_table.private.id
+}

--- a/management/vpc/outputs.tf
+++ b/management/vpc/outputs.tf
@@ -1,0 +1,50 @@
+############################################################
+## VPC
+############################################################
+output "vpc_id" {
+  value = aws_vpc.management.id
+}
+
+output "vpc_cidr_block" {
+  value = aws_vpc.management.cidr_block
+}
+
+output "public_subnet_ids" {
+  value = [
+    aws_subnet.management_public_subnet_1.id,
+    aws_subnet.management_public_subnet_2.id
+  ]
+}
+
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.management_private_subnet_1.id,
+    aws_subnet.management_private_subnet_2.id
+  ]
+}
+
+output "public_route_table_id" {
+  value = aws_vpc.management.default_route_table_id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}
+
+output "public_subnet_az_to_id_map" {
+  value = {
+    for subnet in [
+      aws_subnet.management_public_subnet_1,
+      aws_subnet.management_public_subnet_2
+    ] : subnet.availability_zone => subnet.id
+  }
+}
+
+output "private_subnet_az_to_id_map" {
+  value = {
+    for subnet in [
+      aws_subnet.management_private_subnet_1,
+      aws_subnet.management_private_subnet_2
+    ] : subnet.availability_zone => subnet.id
+  }
+}

--- a/staging/vpc/.terraform.lock.hcl
+++ b/staging/vpc/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.5.0"
+  hashes = [
+    "h1:RW3BccpFsLA0PrYWrQb/UG0TQHe2c0c5ZXYXJeVm4LU=",
+    "zh:10fe0ef4191323c920c1844f27dbc88114547d5f78fad915c1769c908f40d916",
+    "zh:565fc7c3a1f42474fa75f143cb8115e11b894ed7fd9973569b00bd429fb92b4e",
+    "zh:5ba6132b1d442ed679ad8ea89fb5602aa0893e8dcd002a52ab3d76591aa18c8b",
+    "zh:5c2580630cd5034bae800445074c17950aea17f089bcdae7af637173122f8b03",
+    "zh:656d77220c6053fd5adb86d3bfb57dd42f98220d81590ffd643156ffeca36608",
+    "zh:65c7b3e333b734ce641735a23539d4fb392a675a5a9b892e8369781b1f3386a2",
+    "zh:682d55b2e6e9c40e20d679aa53d561797b1f3450e5187c9f4e8c359b69f06df3",
+    "zh:79ebc0993d6128819d70dd896cd743e3bab3e3cdc4c02f2a2dbd138471c23179",
+    "zh:8d44214c738f0410f829e1c761b021c92b3364daf9fcd08097216cc84eaff997",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a0b1bc008e95c5a7285f5e7dd116ce60ba7a6c1c3bd8ac3e3b63d4e1438d8e49",
+    "zh:cf40fb60efc5df42fc5716c7e458868251c82fc78b623f12d1bc994b6fcc7ef2",
+    "zh:cfd8f3f391cddecfc5e44fe57f0633067470e9038517115ba69d8ee533d5d74e",
+    "zh:d6552490599e02a756e72b7091b591493cee25548ce7120ad05210b4ff2492bd",
+    "zh:f77dfe665fd4b3d9e36fdc989d7feff4cf6bf17161c0b1a0f25a0fcf402c779d",
+  ]
+}

--- a/staging/vpc/backend.tf
+++ b/staging/vpc/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "bellti9er-tf-state-prod"
+    key     = "staging/vpc.state"
+    region  = "ap-northeast-2"
+    profile = "bellti9er"
+  }
+}

--- a/staging/vpc/main.tf
+++ b/staging/vpc/main.tf
@@ -1,0 +1,193 @@
+provider "aws" {
+  region = "ap-northeast-2"
+
+  # Terraform by default looks at the ~/.aws/credentials file 
+  # for the aws access key and secret.
+  # The profile config tells which profile credential
+  # to look at in the aws credential file.
+  profile = "bellti9er"
+}
+
+data "terraform_remote_state" "management" {
+  backend = "s3"
+  config  = {
+    bucket = "bellti9er-tf-state-prod"
+    key    = "management/vpc.state"
+    region = "ap-northeast-2"
+  }
+}
+
+############################################################
+## Staging
+############################################################
+resource "aws_vpc" "staging" {
+  cidr_block           = "11.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "Staging"
+  }
+}
+
+############################################################
+# Public Subnets
+############################################################
+resource "aws_subnet" "staging_public_subnet_1" {
+  vpc_id            = aws_vpc.staging.id
+  cidr_block        = "11.0.0.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "Staging Public Subnet 1"
+  }
+}
+
+resource "aws_subnet" "staging_public_subnet_2" {
+  vpc_id            = aws_vpc.staging.id
+  cidr_block        = "11.0.2.0/24"
+  availability_zone = "ap-northeast-2b"
+
+  tags = {
+    Name = "Staging Public Subnet 2"
+  }
+}
+
+############################################################
+# Private Subnets
+############################################################
+resource "aws_subnet" "staging_private_subnet_1" {
+  vpc_id            = aws_vpc.staging.id
+  cidr_block        = "11.0.4.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "Staging Private Subnet 1"
+  }
+}
+
+resource "aws_subnet" "staging_private_subnet_2" {
+  vpc_id            = aws_vpc.staging.id
+  cidr_block        = "11.0.6.0/24"
+  availability_zone = "ap-northeast-2b"
+
+  tags = {
+    Name = "Staging Private Subnet 2"
+  }
+}
+
+############################################################
+# EIP
+############################################################
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+############################################################
+# Routing table for public subnets
+############################################################
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.staging.id
+
+  tags = {
+    Name = "Staging Internet Gateway"
+  }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.staging.default_route_table_id
+
+  tags = {
+    Name = "Staging Public Default Route Table"
+  }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_vpc.staging.default_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.ig.id
+}
+
+resource "aws_route_table_association" "public_1" {
+  subnet_id      = aws_subnet.staging_public_subnet_1.id
+  route_table_id = aws_vpc.staging.default_route_table_id
+}
+
+resource "aws_route_table_association" "public_2" {
+  subnet_id      = aws_subnet.staging_public_subnet_2.id
+  route_table_id = aws_vpc.staging.default_route_table_id
+}
+
+############################################################
+# Routing table for private subnets
+############################################################
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.staging_public_subnet_1.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.staging.id
+
+  tags = {
+    Name = "Staging Private Route Table"
+  }
+}
+
+resource "aws_route" "private" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat.id
+}
+
+resource "aws_route_table_association" "private_1" {
+  subnet_id      = aws_subnet.staging_private_subnet_1.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_2" {
+  subnet_id      = aws_subnet.staging_private_subnet_2.id
+  route_table_id = aws_route_table.private.id
+}
+
+############################################################
+## VPC Peerings
+############################################################
+data "aws_caller_identity" "current" { }
+
+resource "aws_vpc_peering_connection" "management_to_staging" {
+  vpc_id        = data.terraform_remote_state.management.outputs.vpc_id
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = aws_vpc.staging.id
+  auto_accept   = true
+}
+
+############################################################
+# Route from the primary vpc to the secondary vpc
+############################################################
+resource "aws_route" "primary_vpc_public_to_secondary_vpc" {
+  route_table_id            = data.terraform_remote_state.management.outputs.public_route_table_id
+  destination_cidr_block    = aws_vpc.staging.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.management_to_staging.id
+}
+
+resource "aws_route" "primary_vpc_private_to_secondary_vpc" {
+  route_table_id            = data.terraform_remote_state.management.outputs.private_route_table_id
+  destination_cidr_block    = aws_vpc.staging.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.management_to_staging.id
+}
+
+############################################################
+# Route from the secondary vpc to the primary vpc
+############################################################
+resource "aws_route" "secondary_vpc_public_to_primary_vpc" {
+  route_table_id            = aws_default_route_table.default.id
+  destination_cidr_block    = data.terraform_remote_state.management.outputs.vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.management_to_staging.id
+}
+
+resource "aws_route" "secondary_vpc_private_to_primary_vpc" {
+  route_table_id            = aws_route_table.private.id
+  destination_cidr_block    = data.terraform_remote_state.management.outputs.vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.management_to_staging.id
+}

--- a/staging/vpc/outputs.tf
+++ b/staging/vpc/outputs.tf
@@ -1,0 +1,61 @@
+############################################################
+## VPC
+############################################################
+output "vpc_id" {
+  value = aws_vpc.staging.id
+}
+
+output "vpc_cidr_block" {
+  value = aws_vpc.staging.cidr_block
+}
+
+output "public_subnet_ids" {
+  value = [
+    aws_subnet.staging_public_subnet_1.id,
+    aws_subnet.staging_public_subnet_2.id
+  ]
+}
+
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.staging_private_subnet_1.id,
+    aws_subnet.staging_private_subnet_2.id
+  ]
+}
+
+output "public_route_table_id" {
+  value = aws_vpc.staging.default_route_table_id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}
+
+output "public_subnet_az_to_id_map" {
+  value = {
+    for subnet in [
+      aws_subnet.staging_public_subnet_1,
+      aws_subnet.staging_public_subnet_2
+    ] : subnet.availability_zone => subnet.id
+  }
+}
+
+output "private_subnet_az_to_id_map" {
+  value = {
+    for subnet in [
+      aws_subnet.staging_private_subnet_1,
+      aws_subnet.staging_private_subnet_2
+    ] : subnet.availability_zone => subnet.id
+  }
+}
+
+############################################################
+## VPC Peering
+############################################################
+output "vpc_peering_id" { 
+  value = aws_vpc_peering_connection.management_to_staging.id
+}
+
+output "vpc_peering_accept_status" { 
+  value = aws_vpc_peering_connection.management_to_staging.accept_status
+}


### PR DESCRIPTION
## 작업 배경

- management VPC
  - 다른 VPC들을 관리하는 시스템들이 위치하는 가상의 사설 네트워크인 management를 생성합니다.
  - 해당 VPC에 위치하게 될 대표적인 시스템으로는, VPN 혹은 CICD등이 작업 될 예정입니다.
- staging VPC
  - production에 배포 되기 이전의 서비스 관리 및 개발을 위한 staging 시스템들이 위치하는 VPC입니다.

</br>

## 작업 내용

- 아래의 두가지 VPC를 생성합니다.
  - management
  - staging
- 두개의 공용 서브넷과 두개의 사설 서브넷을 생성하여 각각 다른 가용 영역에 위치시킵니다. 이를 통해 보다 고가용성을 보장할 수 있습니다.
- 두개의 서로 다른 VPC를 Peering 연결하여 두 VPC가 서로간의 리소스에 접근 가능 할 수 있게합니다. 

</br>